### PR TITLE
chore: update actions/cache from v1 to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: npm-deps-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.5--canary.26.13413796611.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/web-telemetry@2.0.5--canary.26.13413796611.0
  # or 
  yarn add @salutejs/web-telemetry@2.0.5--canary.26.13413796611.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
