### PR TITLE
Remove math round on telemetry with web vitals

### DIFF
--- a/src/presets/WebTelemetryMonitoringCanvasWithWebVitals.ts
+++ b/src/presets/WebTelemetryMonitoringCanvasWithWebVitals.ts
@@ -1,4 +1,4 @@
-import { onLCP, onFID, onCLS, onFCP, onINP } from 'web-vitals/attribution';
+import { onCLS, onFCP, onFID, onINP, onLCP } from 'web-vitals/attribution';
 
 import type { WebTelemetryAddon, WebTelemetryExtendedConfig, WebTelemetryTransport } from '../types.js';
 
@@ -16,9 +16,7 @@ export class WebTelemetryMonitoringCanvasWithWebVitals extends WebTelemetryMonit
 
     public startWebVitals() {
         [onLCP, onFID, onCLS, onFCP, onINP].forEach((getMetric) => {
-            getMetric(({ name, value, attribution }) =>
-                this.KV.push({ key: name, value: Math.round(value) }, attribution),
-            );
+            getMetric(({ name, value, attribution }) => this.KV.push({ key: name, value: value }, attribution));
         });
     }
 

--- a/src/presets/WebTelemetryMonitoringWebAppWithWebVitals.ts
+++ b/src/presets/WebTelemetryMonitoringWebAppWithWebVitals.ts
@@ -1,4 +1,4 @@
-import { onLCP, onFID, onCLS, onFCP, onINP } from 'web-vitals/attribution';
+import { onCLS, onFCP, onFID, onINP, onLCP } from 'web-vitals/attribution';
 
 import type { WebTelemetryExtendedConfig, WebTelemetryTransport } from '../types.js';
 
@@ -12,9 +12,7 @@ export class WebTelemetryMonitoringWebAppWithWebVitals extends WebTelemetryMonit
 
     public startWebVitals() {
         [onLCP, onFID, onCLS, onFCP, onINP].forEach((getMetric) => {
-            getMetric(({ name, value, attribution }) =>
-                this.KV.push({ key: name, value: Math.round(value) }, attribution),
-            );
+            getMetric(({ name, value, attribution }) => this.KV.push({ key: name, value: value }, attribution));
         });
     }
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.14--canary.33.14342493875.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/web-telemetry@2.0.14--canary.33.14342493875.0
  # or 
  yarn add @salutejs/web-telemetry@2.0.14--canary.33.14342493875.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
